### PR TITLE
add prepare script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "format": "npm run lint -- --fix && prettier --write \"**/*.{js,ts,tsx}\"",
     "lint": "eslint .",
     "postbundle": "npm run clean:compiled && shx cp ./index.js ./dist/index.js",
+    "prepare": "npm run build",
     "release": "tanem-scripts release",
     "test": "run-s check:* lint build test:*",
     "test:cjs": "jest --config ./scripts/jest/config.cjs.js",


### PR DESCRIPTION
This will allow us to use this package from Github repository. We need either this script, or we should put compiled version (`dist` folder) into the repository.