### PR TITLE
Fix the CodeSandbox setup failure in the examples

### DIFF
--- a/examples/material-ui/.codesandbox/tasks.json
+++ b/examples/material-ui/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/multiple-instances/.codesandbox/tasks.json
+++ b/examples/multiple-instances/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/next-app-router/.codesandbox/tasks.json
+++ b/examples/next-app-router/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/next-pages-router/.codesandbox/tasks.json
+++ b/examples/next-pages-router/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/original-design/.codesandbox/tasks.json
+++ b/examples/original-design/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/plain-js/.codesandbox/tasks.json
+++ b/examples/plain-js/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/react-router/.codesandbox/tasks.json
+++ b/examples/react-router/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/render-props/.codesandbox/tasks.json
+++ b/examples/render-props/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }


### PR DESCRIPTION
Every example ran `npm i -g pnpm@latest` as a CodeSandbox setup task before installing. That now resolves to pnpm 11, which requires Node 22.13 and loads `node:sqlite`. The `ghcr.io/codesandbox/devcontainers/typescript-node:latest` image still ships Node 20.12, so the task threw `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` and setup died before `pnpm install` ran.

The upstream [react-vite](https://github.com/codesandbox/sandbox-templates/tree/main/react-vite) and [nextjs](https://github.com/codesandbox/sandbox-templates/tree/main/nextjs) templates no longer have the task and use the pnpm preinstalled in the image. This removes it from all 8 examples to match.

Pinning to `pnpm@10` would also unblock it, but it diverges from the templates and breaks again once CodeSandbox moves the image to Node 22.

Mirrors tanem/react-svg#3595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)